### PR TITLE
fixed bug in read_individial_plate()

### DIFF
--- a/R/read_plates.R
+++ b/R/read_plates.R
@@ -13,32 +13,33 @@
 #' @rdname read_individual_plate
 #' @export
 read_individual_plate <- function(plate_file, path_target, time_vector=c(), sep='\t'){
-  
+
   # Read the data for the file
   plate_df <- read.delim(file.path(path_target, plate_file), sep=sep)
-  
+
   # Make sure there is a Time column
   if(!"Time" %in% colnames(plate_df)){
     stop(paste("No column named 'Time' found in", plate_file))
   }
-  
-  
+
+  # Gather the plate name
+  plate_name <- tools::file_path_sans_ext(plate_file, compression = TRUE)
+
   # Assign the values of the common time_vector to the Time column
   if(length(time_vector) > 0){
     if(nrow(plate_df) != length(time_vector)){
       stop(paste("The length of time_vector does not equal the number of found in", plate_name))
-      
+
     }else{
       plate_df$Time <- time_vector
     }
   }
-  
+
   # Update the well identifiers to include the plate name
-  plate_name <- tools::file_path_sans_ext(plate_file, compression = TRUE)
-  plate_df <- plate_df %>% 
+  plate_df <- plate_df %>%
     rename_with(~paste0(plate_name, "_", .x, recycle0 = TRUE), -Time)
-  
-  
+
+
   return(plate_df)
 }
 
@@ -51,7 +52,7 @@ read_individual_plate <- function(plate_file, path_target, time_vector=c(), sep=
 #' @param time_vector A numeric vector that indicates the Time at which each measurement was taken. If empty then the Time column from one of the plates is taken as reference.
 #' @param sep The delimiter character that separates columns of each file in path_target
 
-#' @return A list of two dataframes. An "od_data" dataframe with a common time column and each growth curve in a separate column named with it's "curve_id" ({plate_name}_{well}). 
+#' @return A list of two dataframes. An "od_data" dataframe with a common time column and each growth curve in a separate column named with it's "curve_id" ({plate_name}_{well}).
 #' Also a "metadata" dataframe indicating the well and the original plate from which each "curve_id" is gathered from.
 #'
 #' @name read_multiple_plates
@@ -61,7 +62,7 @@ read_multiple_plates <- function(path_target, time_vector = c(), sep='\t'){
   # List files in path_target
   plate_files <- list.files(path_target)
   message(paste("The following OD data was found:", paste0(plate_files, collapse = ", ")))
-  
+
   # Send message if time_vector is empty
   if(length(time_vector) == 0){
     message(paste("No common time_vector given. Will use the Time column from", plate_files[1], "as reference."))
@@ -70,24 +71,24 @@ read_multiple_plates <- function(path_target, time_vector = c(), sep='\t'){
                                          time_vector = time_vector,
                                          sep = sep)$Time
   }
-  
+
   # Read the data from the other lists
   # TODO: can be optimized so as to not re-read the first file
-  plates_read_list <- lapply(plate_files, read_individual_plate, path_target=path_target, time_vector=time_vector, sep='\t')
-  
+  plates_read_list <- lapply(plate_files, read_individual_plate, path_target=path_target, time_vector=time_vector, sep=sep)
+
   # Combine all dataframes into one big dataframe
   complete_od <- reduce(plates_read_list, full_join, by="Time")
-  
+
   # Create a mapping dataframe
   curve_ids <- colnames(complete_od)[colnames(complete_od) != "Time"]
   mapper_df <- data.frame(curve_id = curve_ids,
-                          well = str_split_i(curve_ids, "_", -1)) %>% 
+                          well = str_split_i(curve_ids, "_", -1)) %>%
     mutate(plate_name = str_remove(curve_id, paste0("_", well)))
-  
+
   # Return OD and metadata df
-  
+
   return(list("od_data" = complete_od,
               "metadata" = mapper_df))
-  
-  
+
+
 }


### PR DESCRIPTION
There was a bug the read_individual_plate() function where the plate_name variable was referenced before being specified when the time vector was different to the number of rows in the plate.